### PR TITLE
Add: word puzzle input field

### DIFF
--- a/src/components/Puzzles/WordPuzzle/WordPuzzleModal.tsx
+++ b/src/components/Puzzles/WordPuzzle/WordPuzzleModal.tsx
@@ -223,7 +223,7 @@ const handleSubmit = (e: React.FormEvent) => {
       </section>
       <form
       onSubmit={handleSubmit}
-      className="bg-black/60 p-6 rounded-xl w-full max-w-md mx-auto flex flex-col gap-6"
+      className="bg-gray-50/60 p-6 rounded-xl w-full max-w-md mx-auto flex flex-col gap-6"
     >
       <InputField
         id="inputGuess"

--- a/src/components/Puzzles/WordPuzzle/WordPuzzleModal.tsx
+++ b/src/components/Puzzles/WordPuzzle/WordPuzzleModal.tsx
@@ -75,7 +75,8 @@ function DropZone({
 export default function WordPuzzleModal({ isOpen, onClose }: WordPuzzleModalProps) {
   const [selectedWord, setSelectedWord] = useState("");
   const [currentArrangement, setCurrentArrangement] = useState<string[]>([]);
-  
+  const [inputGuess, setInputGuess] = useState("");
+
   // Drag state
   const [draggedIndex, setDraggedIndex] = useState<number | null>(null);
   const [dropZoneIndex, setDropZoneIndex] = useState<number | null>(null);
@@ -146,6 +147,11 @@ export default function WordPuzzleModal({ isOpen, onClose }: WordPuzzleModalProp
     setDropZoneIndex(null);
   };
 
+  // Handle inputfield option 
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  setInputGuess(e.target.value);
+};
+
   return (
     <Modal isOpen={isOpen} onClose={onClose}>
       <section className="p-4">
@@ -211,7 +217,7 @@ export default function WordPuzzleModal({ isOpen, onClose }: WordPuzzleModalProp
         id="inputGuess"
         placeholder="Write your guess instead..."
         value={inputGuess}
-        onChange={(e) => (e.target.value)}
+        onChange={handleInputChange}
         className="w-full"
         required
       />

--- a/src/components/Puzzles/WordPuzzle/WordPuzzleModal.tsx
+++ b/src/components/Puzzles/WordPuzzle/WordPuzzleModal.tsx
@@ -1,5 +1,7 @@
 import { useState, useEffect, Fragment } from 'react';
 import Modal from '@/elements/Modal';
+import Button from "@/elements/Button";
+import InputField from "@/elements/InputField";
 import { getRandomWord } from '@/data/WordPuzzleData';
 import { usePuzzle } from '@/hooks/usePuzzle';
 import { shuffle } from '@/utils/shuffleArray';
@@ -201,6 +203,22 @@ export default function WordPuzzleModal({ isOpen, onClose }: WordPuzzleModalProp
           </div>
         )}
       </section>
+      <form
+      onSubmit={handleSubmit}
+      className="bg-black/60 p-6 rounded-xl w-full max-w-md mx-auto flex flex-col gap-6"
+    >
+      <InputField
+        id="inputGuess"
+        placeholder="Write your guess instead..."
+        value={inputGuess}
+        onChange={(e) => (e.target.value)}
+        className="w-full"
+        required
+      />
+      <Button type="submit" className="bg-green-600 hover:bg-green-700">
+        Enter guess
+      </Button>
+      </form>
     </Modal>
   );
 }

--- a/src/components/Puzzles/WordPuzzle/WordPuzzleModal.tsx
+++ b/src/components/Puzzles/WordPuzzle/WordPuzzleModal.tsx
@@ -152,6 +152,18 @@ export default function WordPuzzleModal({ isOpen, onClose }: WordPuzzleModalProp
   setInputGuess(e.target.value);
 };
 
+const handleSubmit = (e: React.FormEvent) => {
+  e.preventDefault();
+  
+  if (inputGuess.toLowerCase() === selectedWord.toLowerCase()) {
+    // If correct, update the arrangement to match the correct word, if we end up not removing the letters uppon sucess when the design is set!
+    setCurrentArrangement([...selectedWord]);
+    setErrorMessage(null);
+  } else {
+    setErrorMessage("That's not the right word. Try again!");
+  }
+};
+
   return (
     <Modal isOpen={isOpen} onClose={onClose}>
       <section className="p-4">

--- a/src/components/Puzzles/WordPuzzle/WordPuzzleModal.tsx
+++ b/src/components/Puzzles/WordPuzzle/WordPuzzleModal.tsx
@@ -76,6 +76,7 @@ export default function WordPuzzleModal({ isOpen, onClose }: WordPuzzleModalProp
   const [selectedWord, setSelectedWord] = useState("");
   const [currentArrangement, setCurrentArrangement] = useState<string[]>([]);
   const [inputGuess, setInputGuess] = useState("");
+  const [showInput, setShowInput] = useState<boolean>(false);
 
   // Drag state
   const [draggedIndex, setDraggedIndex] = useState<number | null>(null);
@@ -147,8 +148,13 @@ export default function WordPuzzleModal({ isOpen, onClose }: WordPuzzleModalProp
     setDropZoneIndex(null);
   };
 
-  // Handle inputfield option 
-  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+// Handle inputfield option 
+const toggleInputForm = () => {
+  setShowInput(!showInput);
+  /* setErrorMessage(null); */
+};
+
+const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
   setInputGuess(e.target.value);
 };
 
@@ -209,6 +215,14 @@ const handleSubmit = (e: React.FormEvent) => {
                 </Fragment>
               ))}
             </div>
+            <Button
+              type="button"
+              onClick={toggleInputForm}
+              className="bg-gray-200 hover:bg-gray-300 text-gray-800 px-4 py-2 rounded"
+            >
+              {showInput ? "Hide typing option" : "Type your answer instead"}
+            </Button>
+            {showInput && (
             <form
               onSubmit={handleSubmit}
               className="bg-gray-50/60 p-6 rounded-xl w-full max-w-md mx-auto flex flex-col gap-6"
@@ -225,6 +239,7 @@ const handleSubmit = (e: React.FormEvent) => {
                 Enter guess
               </Button>
             </form>
+            )}
           </>
         ) : (
           <div className="text-center">

--- a/src/components/Puzzles/WordPuzzle/WordPuzzleModal.tsx
+++ b/src/components/Puzzles/WordPuzzle/WordPuzzleModal.tsx
@@ -209,6 +209,22 @@ const handleSubmit = (e: React.FormEvent) => {
                 </Fragment>
               ))}
             </div>
+            <form
+              onSubmit={handleSubmit}
+              className="bg-gray-50/60 p-6 rounded-xl w-full max-w-md mx-auto flex flex-col gap-6"
+            >
+              <InputField
+                id="inputGuess"
+                placeholder="Write your guess instead..."
+                value={inputGuess}
+                onChange={handleInputChange}
+                className="w-full"
+                required
+              />
+              <Button type="submit" className="bg-green-600 hover:bg-green-700">
+                Enter guess
+              </Button>
+            </form>
           </>
         ) : (
           <div className="text-center">
@@ -221,22 +237,6 @@ const handleSubmit = (e: React.FormEvent) => {
           </div>
         )}
       </section>
-      <form
-      onSubmit={handleSubmit}
-      className="bg-gray-50/60 p-6 rounded-xl w-full max-w-md mx-auto flex flex-col gap-6"
-    >
-      <InputField
-        id="inputGuess"
-        placeholder="Write your guess instead..."
-        value={inputGuess}
-        onChange={handleInputChange}
-        className="w-full"
-        required
-      />
-      <Button type="submit" className="bg-green-600 hover:bg-green-700">
-        Enter guess
-      </Button>
-      </form>
     </Modal>
   );
 }


### PR DESCRIPTION
Added input-field option for WordPuzzle for accessibility with a toggle to show. Separate logic for checking if correct guess and re-arranging the words by the drag-and-drop to the correct one if we decide to not hide the letters during the success message. 